### PR TITLE
Update support.blade.php

### DIFF
--- a/app/views/support.blade.php
+++ b/app/views/support.blade.php
@@ -12,16 +12,16 @@
     </h4>
 
     {{ Form::open(array('url' => '/support', 'class'=>'form-horizontal')) }}
-
-        <span class="col-sm-12 text-left text-danger">{{ $errors->first('first_name') }}</span>
+        
+        <label class="text-left text-danger">{{ $errors->first('first_name') }}</label>
         {{ Form::text('first_name', '',  array('class'=>"form-control", 'placeholder'=>'First Name*')) }}
         <br>
 
-        <span class="col-sm-12 text-left text-danger">{{ $errors->first('last_name') }}</span>
+        <label class="text-left text-danger">{{ $errors->first('last_name') }}</label>
         {{ Form::text('last_name', '', array('class'=>"form-control", 'placeholder'=> 'Last Name*')) }}
         <br>
 
-        <span class="col-sm-12 text-left text-danger">{{ $errors->first('email') }}</span>
+        <label class="text-left text-danger">{{ $errors->first('email') }}</label>
         {{ Form::text('email', '', array('class'=>"form-control" , 'placeholder'=> 'Email Address*')) }}
         <br>
 


### PR DESCRIPTION
Float left on col-sm-12, for the error presentation, was causing the first field to flow left on Firefox 

Replaced it label element and removed the floating, which stopped the problem for my browser.

![the code manifesto 2015-02-05 21-25-59](https://cloud.githubusercontent.com/assets/1970839/6073537/9ce6b51a-ad7d-11e4-85da-ae577c9fc4c2.png)
