### PR TITLE
"First name" field on support form does not align

### DIFF
--- a/app/views/support.blade.php
+++ b/app/views/support.blade.php
@@ -13,6 +13,7 @@
 
     {{ Form::open(array('url' => '/support', 'class'=>'form-horizontal')) }}
 
+        <br>
         <span class="col-sm-12 text-left text-danger">{{ $errors->first('first_name') }}</span>
         {{ Form::text('first_name', '',  array('class'=>"form-control", 'placeholder'=>'First Name*')) }}
         <br>


### PR DESCRIPTION

![bildschirmfoto vom 2015-03-07 12 53 35](https://cloud.githubusercontent.com/assets/189796/6541330/7e293dce-c4c9-11e4-9842-1d7e6d06976c.png)


Simple fix by addind a `<br>`.