### PR TITLE
Remove committment to proffessional values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 The Code Manifesto
 ==================
 
-We want to work in an ecosystem that empowers developers to reach their potential--one that encourages professional growth and effective collaboration. A space that is safe for all.
+We want to work in an ecosystem that empowers developers to reach their potential--one that encourages growth and effective collaboration. A space that is safe for all.
 
 A space such as this benefits everyone that participates in it. It encourages new developers to enter our field. It is through discussion and collaboration that we grow, and through growth that we improve.
 


### PR DESCRIPTION
I suggest you avoid encouraging *professional* growth as a goal as it is rather narrow and political. 

The role of professionals is to serve the needs of their employers. But there are other things that people aspire to, such as serving clients, serving the public, serving special interest groups (advocacy), contributing to a better society, disrupting evil-doers, pursuing individual curiosity, having fun.  These aims are often at odds with the aims of the employers of professional computer programmers. Hence the values and attitudes of the professional computer programmer are narrow and conservative relative to the values and attitudes of all of those who are interested in exploring computer programming and developing their skills.

There are many fine people who program computers to do wonderful things who have attitudes and behaviors that are not at all like a professional. I'm sure we can all think of examples.

If you are unfamiliar with the political nature of the professional class, I recommend Jeff Schmidt's book “Disciplined Minds.”